### PR TITLE
Add banner with example session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN set -xe \
 
 ADD vsftpd.conf /etc/vsftpd/vsftpd.conf
 ADD vsftpd.email_passwords /etc/vsftpd.email_passwords
+ADD banner.txt /etc/vsftpd.banner
 # Log to docker stdout (vsftpd must be run as PID 1)
 RUN ln -sf /proc/1/fd/1 /var/log/vsftpd.log
 

--- a/banner.txt
+++ b/banner.txt
@@ -1,0 +1,32 @@
+***************************************************************
+Anonymous FTP Upload
+
+Place individual files in /incoming. If you intend
+to upload a number of files, create a subdirectory
+under /incoming.  Only login as "anonymous" with a
+valid password is supported!
+
+Example session:
+
+	ftp> user anonymous
+	331 Please specify the password.
+	Password:
+	331 Please specify the password.
+	Password:
+	230 Login successful.
+	ftp> cd incoming
+	250 Directory successfully changed.
+	ftp> mkdir my-dataset
+	257 "/incoming/my-dataset" created
+	ftp> cd my-dataset
+	250 Directory successfully changed.
+	ftp> prompt
+	Interactive mode off.
+	ftp> mput *.tiff
+	local: 0001.tiff remote: 0001.tiff
+	227 Entering Passive Mode (172,17,0,19,82,46).
+	150 Ok to send data.
+	226 Transfer complete.
+	16070 bytes sent in 0.000634 secs (25347.00 Kbytes/sec)
+    
+***************************************************************

--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -86,7 +86,7 @@ nopriv_user=ftp
 #ascii_download_enable=YES
 #
 # You may fully customise the login banner string:
-ftpd_banner=Place files in /incoming for upload.
+banner_file=/etc/vsftpd.banner
 #
 # You may specify a file of disallowed anonymous e-mail addresses. Apparently
 # useful for combatting certain DoS attacks.


### PR DESCRIPTION
Using this as a general review of the repo:

 * Builds quickly.
 * Logs work nicely.
 * Anonymous and named volumes work well. :+1:
 * Bind volumes of local directories would require some work to get the permissions correct, I think. (I agree that the docker shouldn't be responsible for `chmod`'ing like `postgres` does since that can be dangerous)
 * If we ever add our own entrypoint, allowing to override the password without needing to rebuild the image would probably be welcome, especially for one-off upload containers. (e.g. `ANONYMOUS_PASSWORD` gets written to `/etc/vsftpd.email_passwords` *IFF* the file wasn't mounted)

I'm not completely sure about the banner text, but I'd suggest we provide a little more help for the uninformed user (cc: @sbesson @melissalinkert @kennethgillen @jburel)

From my point-of-view, with or without this PR this can be migrated to @openmicroscopy so we can create a hub build.
