### PR TITLE
Add an optional rsync/ssh sidecar to access the ftp volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ftp> rm test.txt
 
 An experimental Kubernetes Helm chart is included (note the TODOs regarding configuration).
 ```
-helm upgrade --install --namespace=vsftpd vsftpd ./helm -f helm-example-config/config.yaml -f <volume-config>.yaml
+helm upgrade --install --namespace=vsftpd vsftpd ./helm -f helm-example-config/config.yaml [-f <volume-config>.yaml]
 ```
 
 

--- a/helm-example-config/config.yaml
+++ b/helm-example-config/config.yaml
@@ -1,6 +1,6 @@
-service:
-  type: NodePort
 ftp:
+  service:
+    type: NodePort
   passive:
     resolveAddress: true
     address: ftp.example.org

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,15 +1,15 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
+{{- if contains "NodePort" .Values.ftp.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services vsftpd-anon)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.ftp.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "helm.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} vsftpd-anon -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.ftp.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.ftp.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=vsftpd-anon,release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+  kubectl port-forward $POD_NAME 8080:{{ .Values.ftp.service.internalPort }}
 {{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,3 +1,4 @@
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -44,3 +45,14 @@ data:
 
   vsftpd.banner: |
     {{ .Values.ftp.banner }}
+
+---
+{{ if and .Values.rsync.enabled .Values.ftp.pvc.enabled }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rsync-ssh-users
+data:
+  GROUPID: "{{ .Values.rsync.groupId }}"
+  GITHUB_USERS: "{{- range $e := .Values.rsync.githubUsers }} {{ . }} {{- end }}
+{{- end }}"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,11 +17,12 @@ spec:
         app: vsftpd-anon
         release: {{ .Release.Name }}
     spec:
+
       {{- if and .Values.ftp.pvc.enabled .Values.ftp.pvc.setIncomingPermissions }}
       initContainers:
         - name: vsftpd-anon-init
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.ftp.image.repository }}:{{ .Values.ftp.image.tag }}"
+          imagePullPolicy: {{ .Values.ftp.image.pullPolicy }}
           command:
             - sh
             - -x
@@ -31,12 +32,14 @@ spec:
             - name: vsftp-incoming
               mountPath: /var/lib/ftp/incoming
       {{- end }}
+
       containers:
+
         - name: vsftpd-anon
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.ftp.image.repository }}:{{ .Values.ftp.image.tag }}"
+          imagePullPolicy: {{ .Values.ftp.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.service.internalPort }}
+            - containerPort: {{ .Values.ftp.service.internalPort }}
           {{- range $e := until (sub .Values.ftp.passive.portMax .Values.ftp.passive.portMin | add1 | int) }}
             - containerPort: {{ add $.Values.ftp.passive.portMin . }}
           {{- end }}
@@ -55,6 +58,29 @@ spec:
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+
+      {{- if and .Values.rsync.enabled .Values.ftp.pvc.enabled }}
+        - name: rsync-ssh
+          image: "{{ .Values.rsync.image.repository }}:{{ .Values.rsync.image.tag }}"
+          imagePullPolicy: {{ .Values.rsync.image.pullPolicy }}
+          ports:
+            - containerPort: 22
+          livenessProbe:
+            tcpSocket:
+              port: 22
+          readinessProbe:
+            tcpSocket:
+              port: 22
+          envFrom:
+            - configMapRef:
+                name: rsync-ssh-users
+          volumeMounts:
+            - name: vsftp-incoming
+              mountPath: /var/lib/ftp/incoming
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      {{- end }}
+
       volumes:
         - name: vsftpd-config
           configMap:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,14 +9,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.ftp.service.type }}
   ports:
-    - port: {{ .Values.service.internalPort }}
-      targetPort: {{ .Values.service.internalPort }}
+    - port: {{ .Values.ftp.service.internalPort }}
+      targetPort: {{ .Values.ftp.service.internalPort }}
       protocol: TCP
       name: ftp
-      {{- if and (contains "NodePort" .Values.service.type) .Values.service.externalPort }}
-      nodePort: {{ .Values.service.externalPort }}
+      {{- if and (contains "NodePort" .Values.ftp.service.type) .Values.ftp.service.externalPort }}
+      nodePort: {{ .Values.ftp.service.externalPort }}
       {{- end }}
     {{- range $e := until (sub .Values.ftp.passive.portMax .Values.ftp.passive.portMin | add1 | int) }}
     {{- $port:= add $.Values.ftp.passive.portMin . }}
@@ -23,10 +24,36 @@ spec:
       targetPort: {{ $port }}
       protocol: TCP
       name: ftp-pasv-{{ $port }}
-      {{- if contains "NodePort" $.Values.service.type }}
+      {{- if contains "NodePort" $.Values.ftp.service.type }}
       nodePort: {{ $port }}
       {{- end }}
     {{- end }}
   selector:
     app: vsftpd-anon
     release: {{ .Release.Name }}
+
+---
+{{ if and .Values.rsync.enabled .Values.ftp.pvc.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: rsync-ssh
+  labels:
+    app: rsync-ssh
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.rsync.service.type }}
+  ports:
+    - port: 22
+      targetPort: 22
+      protocol: TCP
+      name: ssh
+      {{- if and (contains "NodePort" .Values.rsync.service.type) .Values.rsync.service.externalPort }}
+      nodePort: {{ .Values.rsync.service.externalPort }}
+      {{- end }}
+  selector:
+    app: vsftpd-anon
+    release: {{ .Release.Name }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,14 +1,14 @@
 # Default values for helm.
 replicaCount: 1
-image:
-  repository: manics/vsftpd-anonymous-upload
-  tag: latest
-  pullPolicy: IfNotPresent
-service:
-  type: ClusterIP
-  externalPort: 32021
-  internalPort: 21
 ftp:
+  image:
+    repository: manics/vsftpd-anonymous-upload
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    externalPort: 32021
+    internalPort: 21
   passive:
     portMin: 32022
     portMax: 32041
@@ -23,9 +23,21 @@ ftp:
     storage:
     setIncomingPermissions: false
     incomingPermissions: "u+wx,u-r,g+rwxs,o-rwx"
-    incomingGroup: root
+    incomingGroup: 1000
   email_passwords:
     allowed:
     - allowed@example.org
   banner: "Place files in /incoming for upload"
 resources: {}
+
+rsync:
+  image:
+    repository: manics/rsync-ssh
+    tag: latest
+    pullPolicy: IfNotPresent
+  enabled: false
+  groupId: 1000
+  githubUsers:
+  service:
+    type: ClusterIP
+    externalPort: 32020


### PR DESCRIPTION
Adds an option to run https://github.com/manics/rsync-ssh-docker/tree/v0.0.1 in the same pod to provide access to the ftp incoming directory